### PR TITLE
refactor (crypto): support pycryptodome

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@ A python module that produces Jasypt/Bouncycastle compatible hashes and encrypte
 
 ### Prerequisites
 
-Any python environment that can run `pycrypto`.
+Any python environment with a module that can service `import Crypto`
+
+pycryptodome is recommended: https://github.com/Legrandin/pycryptodome
+
+```sh
+pip install -r requirements
+```
+
+### Test
+
+```sh
+python3 setup.py test
+```
 
 ### Installation
 

--- a/jasypt4py/encryptor.py
+++ b/jasypt4py/encryptor.py
@@ -61,7 +61,7 @@ class StandardPBEStringEncryptor(object):
         :param s: str - the string to pad
         :return: a padded string that can be fed to the cipher
         """
-        return s + (block_size - len(s) % block_size) * chr(block_size - len(s) % block_size)
+        return bytes(s + (block_size - len(s) % block_size) * chr(block_size - len(s) % block_size), 'utf-8')
 
     @staticmethod
     def unpad(s):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pycrypto >= 2.6
+pycryptodome >= 2.6


### PR DESCRIPTION
very small change found in https://stackoverflow.com/questions/52166887/typeerror-object-type-class-str-cannot-be-passed-to-c-code to support https://github.com/Legrandin/pycryptodome as an alternative to  https://github.com/dlitz/pycrypto (unmaintained? last update 2014)